### PR TITLE
Feature/fix initial username generation

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -28,17 +28,34 @@ returns trigger
 language plpgsql
 security definer set search_path = public
 as $$
-begin
-insert into public.user (uuid, email, username)
-values (new.id, new.email , new.email);
-return new;
-end;
+DECLARE
+  username_text TEXT;
+BEGIN
+  -- Extract the username from the email (word before @), limited to 4 characters
+  username_text := SUBSTRING(NEW.email FROM 1 FOR POSITION('@' IN NEW.email) - 1);
+  IF LENGTH(username_text) > 4 THEN
+    username_text := LEFT(username_text, 4);
+  END IF;
 
+  -- Ensure the username doesn't exceed 10 characters in total
+  IF LENGTH(username_text) + 4 > 10 THEN
+    username_text := LEFT(username_text, 10 - 4);
+  END IF;
+
+  -- Append the first 4 characters of the uuid (id) to the username
+  username_text := username_text || LEFT(NEW.id::TEXT, 4);
+
+  -- Insert the new user with the generated username
+  INSERT INTO public.user (uuid, email, username)
+  VALUES (NEW.id, NEW.email, username_text);
+
+  RETURN NEW;
+END;
 $$
 ;
 
 -- trigger the function every time a user is created
-create trigger on_auth_user_created
+create or replace trigger on_auth_user_created
   after insert on auth.users
   for each row execute procedure public.handle_new_user();
 ```

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -37,11 +37,6 @@ BEGIN
     username_text := LEFT(username_text, 4);
   END IF;
 
-  -- Ensure the username doesn't exceed 10 characters in total
-  IF LENGTH(username_text) + 4 > 10 THEN
-    username_text := LEFT(username_text, 10 - 4);
-  END IF;
-
   -- Append the first 4 characters of the uuid (id) to the username
   username_text := username_text || LEFT(NEW.id::TEXT, 4);
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Welcome to Referalah! Referalah is a platform that connects people, facilitating friendships, connections, and referrals. Whether you're looking to expand your network, find like-minded individuals, or seek referral, Referalah is the place to be. Our website link is [here](https://www.referalah.com/), and our instagram is [here](https://instagram.com/referalah?igshid=NGVhN2U2NjQ0Yg==).
 
-歡迎嚟到 Referalah ! 呢個係一個開源嘅海外港人搵 connections 平台，大家可以喺到搵朋友，referrals，開拓人脈。人在海外，互相幫助，互相支持。篤[呢到](https://www.referalah.com/)去我地網頁，[篤呢](https://instagram.com/referalah?igshid=NGVhN2U2NjQ0Yg==)到去我地 Instagram
+歡迎嚟到 Referalah ! 呢個係一個開源嘅海外港人搵 connections 平台，大家可以喺到搵朋友，referrals，開拓人脈。人在海外，互相幫助，互相支持。篤[呢到](https://www.referalah.com/)去我地網頁，篤[呢到](https://instagram.com/referalah?igshid=NGVhN2U2NjQ0Yg==)去我地 Instagram
 
 ## Developer | IT 人
 

--- a/supabase/migrations/20231005012958_fix_hanlde_new_user_function.sql
+++ b/supabase/migrations/20231005012958_fix_hanlde_new_user_function.sql
@@ -1,0 +1,36 @@
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  username_text TEXT;
+BEGIN
+  -- Extract the username from the email (word before @), limited to 4 characters
+  username_text := SUBSTRING(NEW.email FROM 1 FOR POSITION('@' IN NEW.email) - 1);
+  IF LENGTH(username_text) > 4 THEN
+    username_text := LEFT(username_text, 4);
+  END IF;
+
+  -- Ensure the username doesn't exceed 10 characters in total
+  IF LENGTH(username_text) + 4 > 10 THEN
+    username_text := LEFT(username_text, 10 - 4);
+  END IF;
+
+  -- Append the first 4 characters of the uuid (id) to the username
+  username_text := username_text || LEFT(NEW.id::TEXT, 4);
+
+  -- Insert the new user with the generated username
+  INSERT INTO public.user (uuid, email, username)
+  VALUES (NEW.id, NEW.email, username_text);
+
+  RETURN NEW;
+END;
+
+$function$
+;
+
+

--- a/supabase/migrations/20231005132657_fix_hanlde_new_user_function.sql
+++ b/supabase/migrations/20231005132657_fix_hanlde_new_user_function.sql
@@ -15,14 +15,11 @@ BEGIN
     username_text := LEFT(username_text, 4);
   END IF;
 
-  -- Ensure the username doesn't exceed 10 characters in total
-  IF LENGTH(username_text) + 4 > 10 THEN
-    username_text := LEFT(username_text, 10 - 4);
-  END IF;
+  
 
   -- Append the first 4 characters of the uuid (id) to the username
   username_text := username_text || LEFT(NEW.id::TEXT, 4);
-
+  
   -- Insert the new user with the generated username
   INSERT INTO public.user (uuid, email, username)
   VALUES (NEW.id, NEW.email, username_text);


### PR DESCRIPTION
That's a bad idea to trim first character from email to be username.
Update new logic to generate initial username with email and uuid. 