### PR TITLE
add global loading placeholder during rendering

### DIFF
--- a/client/app/loading.tsx
+++ b/client/app/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return <div
+    className="h-screen flex justify-center items-center text-xl"
+   >
+    Loading...
+  </div>
+}

--- a/client/app/loading.tsx
+++ b/client/app/loading.tsx
@@ -1,7 +1,9 @@
+import { Icons } from "@/components/icons"
+
 export default function Loading() {
-  return <div
-    className="h-screen flex justify-center items-center text-xl"
-   >
-    Loading...
-  </div>
+  return (
+    <div className="h-screen flex justify-center items-center">
+      <Icons.loader className="animate-spin text-2xl" />
+    </div>
+  )
 }


### PR DESCRIPTION
Add a global loading placeholder during rendering.
This is a demo of how to use the nextjs loading ui. Ref: [https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming](https://nextjs.org/docs/app/building-your-application/routing/loading-ui-and-streaming)
We probably need a better design.