### PR TITLE
remove unnecessary h-screen to fix header overflow

### DIFF
--- a/client/modules/main/template.tsx
+++ b/client/modules/main/template.tsx
@@ -29,7 +29,7 @@ const MainPageTemplate = ({
   const scopedT = useScopedI18n("index")
 
   return (
-    <div className="relative mt-2 flex h-screen w-full flex-row items-center justify-center md:h-auto">
+    <div className="relative mt-2 flex w-full flex-row items-center justify-center md:h-auto">
       <div className="relative z-30 mx-auto h-fit w-full max-w-7xl overflow-hidden  p-4 ">
         <motion.div
           initial={{


### PR DESCRIPTION
![image](https://github.com/Pjaijai/Referalah/assets/6291773/7e1f4a75-7daf-453d-8064-0a43a96ef425)
而家喺iphone睇個header會縮咗入去，就咁睇似乎係唔需要`h-screen`，remove咗就ok