### PR TITLE
Docs/README accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Referalah
 
-## Introduction
+## 👋 Introduction
 
-Welcome to Referalah! Referalah is a platform that connects people, facilitating friendships, connections, and referrals. Whether you're looking to expand your network, find like-minded individuals, or seek referral, Referalah is the place to be. Our website link is [here](https://www.referalah.com/), and our instagram is [here](https://instagram.com/referalah?igshid=NGVhN2U2NjQ0Yg==).
+Welcome to Referalah! Referalah is a platform that connects people, facilitating friendships, connections, and referrals. Whether you're looking to expand your network, find like-minded individuals, or seek referral, Referalah is the place to be. Check out our [website](https://www.referalah.com/), and follow our [Instagram](https://instagram.com/referalah?igshid=NGVhN2U2NjQ0Yg==)!
 
-歡迎嚟到 Referalah ! 呢個係一個開源嘅海外港人搵 connections 平台，大家可以喺到搵朋友，referrals，開拓人脈。人在海外，互相幫助，互相支持。篤[呢到](https://www.referalah.com/)去我地網頁，篤[呢到](https://instagram.com/referalah?igshid=NGVhN2U2NjQ0Yg==)去我地 Instagram
+歡迎嚟到 Referalah ! 呢個係一個開源嘅海外港人搵 connections 平台，大家可以喺到搵朋友，referrals，開拓人脈。人在海外，互相幫助，互相支持。可以睇睇我哋嘅[平台網頁](https://www.referalah.com/)，同埋follow我哋嘅[Instagram](https://instagram.com/referalah?igshid=NGVhN2U2NjQ0Yg==)！
 
-## Developer | IT 人
+## 👩🏻‍💻 Developer | IT 人
 
 Please check [INTRODUCTION.md](docs/INTRODUCTION.md)
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## 👋 Introduction
 
-Welcome to Referalah! Referalah is a platform that connects people, facilitating friendships, connections, and referrals. Whether you're looking to expand your network, find like-minded individuals, or seek referral, Referalah is the place to be. Check out our [website](https://www.referalah.com/), and follow our [Instagram](https://instagram.com/referalah?igshid=NGVhN2U2NjQ0Yg==)!
+Welcome to Referalah! Referalah is a platform that connects people, facilitating friendships, connections, and referrals. Whether you're looking to expand your network, find like-minded individuals, or seek referral, Referalah is the place to be. Check out [our website](https://www.referalah.com/), and follow [our Instagram](https://instagram.com/referalah?igshid=NGVhN2U2NjQ0Yg==)!
 
-歡迎嚟到 Referalah ! 呢個係一個開源嘅海外港人搵 connections 平台，大家可以喺到搵朋友，referrals，開拓人脈。人在海外，互相幫助，互相支持。可以睇睇我哋嘅[平台網頁](https://www.referalah.com/)，同埋follow我哋嘅[Instagram](https://instagram.com/referalah?igshid=NGVhN2U2NjQ0Yg==)！
+歡迎嚟到 Referalah ! 呢個係一個開源嘅海外港人搵 connections 平台，大家可以喺到搵朋友，referrals，開拓人脈。人在海外，互相幫助，互相支持。可以睇睇[我哋嘅平台網頁](https://www.referalah.com/)，同埋follow[我哋嘅Instagram](https://instagram.com/referalah?igshid=NGVhN2U2NjQ0Yg==)！
 
 ## 👩🏻‍💻 Developer | IT 人
 


### PR DESCRIPTION
**PR Description**

This PR addresses accessibility issues for users who rely on screen readers.

Previously, some links used the generic text `(click) here`. This is not an accessible practice because:

* Screen reader users often navigate by jumping from link to link, and hearing only “click here” provides no context about the destination.
* Descriptive link text helps all users (including those scanning visually) and improves SEO.

**Fix**
Replaced `here`-style hyperlinks with meaningful, descriptive link text that clearly conveys the purpose of each link.
